### PR TITLE
Implement Zooming

### DIFF
--- a/TrackEditor.cs
+++ b/TrackEditor.cs
@@ -1,7 +1,8 @@
-﻿using AdvancedEdit.Compression;
-using AdvancedEdit.TrackData;
+﻿using AdvancedEdit.TrackData;
 using AdvancedEdit.Types;
 using AdvancedEdit.UI;
+using System.Diagnostics;
+using System.Drawing;
 using static SDL2.SDL;
 
 namespace AdvancedEdit
@@ -15,6 +16,8 @@ namespace AdvancedEdit
         TrackId track = TrackId.PeachCircuit;
         bool tilemapDragged = false;
         bool leftDown = false;
+
+        private Point mousePosition = new(0, 0);
 
         public TrackEditor()
         {
@@ -73,10 +76,10 @@ namespace AdvancedEdit
         }
         public void Draw()
         {
-            tilemap.DrawElement();
-            tilePalette.DrawElement();
+            tilemap.Draw();
+            tilePalette.Draw();
 
-            tile.DrawElement();
+            tile.Draw();
         }
         public void MouseMotion(SDL_Event e)
         {
@@ -84,6 +87,7 @@ namespace AdvancedEdit
             {
                 tilemap.ContentPosition = new(tilemap.ContentPosition.X + e.motion.xrel, tilemap.ContentPosition.Y + e.motion.yrel);
             }
+            mousePosition = new(e.motion.x, e.motion.y);
         }
         public void MouseDown(SDL_Event e)
         {
@@ -111,13 +115,25 @@ namespace AdvancedEdit
                 tilemapDragged = false;
             }
         }
+
+
         public void ScrollWheel(SDL_Event e)
         {
-            if (e.wheel.y != 0)
-            {
-                tilemap.tileSize += e.wheel.y / Math.Abs(e.wheel.y);
-                tilemap.tileSize = Math.Clamp(tilemap.tileSize, 1, 32);
-            }   
+            if (e.wheel.y == 0) return;
+
+            var scroll = e.wheel.y / Math.Abs(e.wheel.y);
+            tilemap.tileSize = Math.Clamp(tilemap.tileSize + scroll, 1, 32);
+
+            var offsetX = tilemap.rows * tilemap.tileSize / 2;
+            var offsetY = tilemap.columns * tilemap.tileSize / 2;
+
+            tilemap.ContentPosition = new Point
+            (
+                mousePosition.X - offsetX,
+                mousePosition.Y - offsetY
+            );
+
+            
         }
     }
 }

--- a/UI/UITile.cs
+++ b/UI/UITile.cs
@@ -48,5 +48,15 @@ namespace AdvancedEdit.UI
             SDL_RenderCopy(Program.Renderer, tileAtlas, ref s, ref d);
             SDL_RenderSetClipRect(Program.Renderer, IntPtr.Zero);
         }
+
+        public override void Update()
+        {
+            // No Updates
+        }
+
+        public override void Events(SDL_Event e)
+        {
+            // No events
+        }
     }
 }


### PR DESCRIPTION
Fixes Issue #1

Small additional changes to make the code compile.

Notes: e.motion.x and e.motion.y don't do what you think with a ScrollWheel event. 

If you break in your scrollwheel method, you'll see that E returns e.motion values similar to e.wheel. Not absolute mouse positions.   e.motion.x is always 0. And e.motion.y is -1 or 1 dependent on which way you scrolled. This is probably why you aren't getting the results you want. 

You'll need to track mouse position inside MouseMotion event. And use that position for the scrolling. 
